### PR TITLE
Add: API for providing content on the main page.

### DIFF
--- a/config/cron.py
+++ b/config/cron.py
@@ -37,7 +37,7 @@ def popular_videos_get_youtube_api():
             published_at          = item['snippet']['publishedAt'],
             content_categories_id = youtube_obj.id,
         )
-        if item['topicDetails'].get('topicCategories'):
+        if item.get('topicDetails'):
             tags = item['topicDetails']['topicCategories']
             for tag in tags:
                 tag_obj, created = Tag.objects.get_or_create(name = tag.split('/')[-1])

--- a/contents/urls.py
+++ b/contents/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from .views import SearchContentView
+from .views import SearchContentView, ContentListView
 
 urlpatterns = [
     path('/search', SearchContentView.as_view()),
+    path('', ContentListView.as_view()),
 ]

--- a/contents/views.py
+++ b/contents/views.py
@@ -3,9 +3,12 @@ import json, requests
 from django.http       import JsonResponse
 from django.conf       import settings
 from django.views      import View
+from django.db.models  import Q
 from json.decoder      import JSONDecodeError
 
 from .models           import *
+from users.models      import *
+from core.views        import login_required
 
 
 class SearchContentView(View):
@@ -43,3 +46,56 @@ class SearchContentView(View):
         ]
 
         return JsonResponse({'message': result, 'page' : page}, status=200)
+
+
+class ContentListView(View):
+    @login_required
+    def get(self, request):
+        category = request.GET.get('category')
+        user     = request.user
+        OFFSET   = int(request.GET.get('offset', 0))
+        LIMIT    = int(request.GET.get('display', 8))
+
+        q = Q()
+        ordering_priority = []
+
+        if category == 'customize':
+            hitoryies = user.user_histories.all()
+
+            if hitoryies:
+                contents  = [history.rooms_contents.all() for history in hitoryies]
+                tag_list  = [content[0].content_tags.all() for content in contents]
+                tags_ids  = list(set([tag[0].id for tag in tag_list]))
+                
+                sort = '-view_count'
+                ordering_priority.append(sort)
+                q.add(Q(content_tags__id__in = tags_ids), q.AND)
+            
+            else:
+                sort = ['?', '-view_count']
+                ordering_priority.extend(sort)
+                q = Q()
+        
+        if category == 'popular':
+            sort = '-created_at'
+            ordering_priority.append(sort)
+            q = Q()
+
+        contents = Content.objects.filter(q).select_related('content_categories').order_by(*ordering_priority).distinct()[OFFSET:OFFSET+LIMIT]
+        
+        result = [
+            {   
+                'id'            : content.id,
+                'category'      : content.content_categories.name,
+                'link_url'      : content.content_link_url,
+                'title'         : content.title,
+                'image_url'     : content.thumbnails_url,
+                'channel_id'    : content.channel_id,
+                'channel_title' : content.channel_title,
+                'running_time'  : content.running_time,
+                'view_count'    : content.view_count,
+                'published_at'  : content.published_at,
+            } for content in contents
+        ]
+
+        return JsonResponse({'message': result}, status=200)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- 메인페이지 content 제공 API 구현

<br />

## :: 구현 사항 설명
1. libido 페이지 contents list 제공
 - 사용자가 입장했던 방의 history 정보를 바탕으로 해당 방의 tag를 추출하여 유사 content 제공
 - 사용자가 입장했던 방의 history 정보가 존재하지 않을 경우에는 조회수 기준으로 content 제공

2. trending 페이지 contents list 제공
- youtube api를 통해 정기적으로 인기 content를 DB에 저장한 뒤, DB에서 최신순으로 content 제공

<br />

## :: 추후 계획
- RoomListView API 구현

<br />

## :: 특이 사항
- crontab 에러 fix
- postman을 통해 통신 확인