### PR TITLE
Add: API to provide a room list on the friend page

### DIFF
--- a/rooms/urls.py
+++ b/rooms/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from .views import RoomListView
+from .views import RoomListView, FriendRoomView
 
 urlpatterns = [
     path('', RoomListView.as_view()),
+    path('/friends', FriendRoomView.as_view()),
 ]


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [x] 컨벤션 수정

<br />

## :: 구현 목표
- friend 페이지에 room list 제공 API 구현

<br />

## :: 구현 사항 설명
1. follow 테이블에서 해당 유저와 follow인 유저를 찾아 해당 유저가 생성한 room 객체 제공

<br />

## :: 추후 계획
- UserFollowView API 구현

<br />

## :: 특이 사항
- RoomListView와 통합하려햇으나, 별도로 분리