### PR TITLE
modify: users/platform_id length fix

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -13,7 +13,7 @@ class User(TimeStampModel):
     nickname           = models.CharField(max_length=30, unique=True)
     profile_image_url  = models.URLField(max_length=2000, null=True)
     login_method       = models.CharField(max_length=30, null=True)
-    platform_id        = models.CharField(max_length=30, null=True)
+    platform_id        = models.CharField(max_length=100, null=True)
     description        = models.TextField(null=True)
     reset_token_number = models.CharField(max_length=30, null=True)
     user_histories     = models.ManyToManyField('rooms.Room', through="rooms.UserRoomHistory", related_name="users_histories")


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표

- users/platform_id 길이 값 수정

<br />

## :: 구현 사항 설명

- 소셜 로그인 시 받아오는 id 값이 기본 설정값인 30보다 많은 경우들이 많아서 100으로 변경함.

2. requirements.txt 추가 사항


3. Setting 관련


<br />

## :: 추후 계획


<br />

## :: 특이 사항
- 없음