### PR TITLE
Add: Implementing a UserHistoryView API that stores room entry records.

### DIFF
--- a/users/urls.py
+++ b/users/urls.py
@@ -13,4 +13,5 @@ urlpatterns = [
     path("/google/login", GoogleSignInView.as_view()),
     path("/naver/login", NaverSignInView.as_view()),
     path("/follows", UserFollowView.as_view()),
+    path("/history", UserHistoryView.as_view()),
 ]


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- 방 입장 기록을 저장하는 UserHistoryView API 구현

<br />

## :: 구현 사항 설명
1. 생성된 방에 대한 history 저장 post API
- 사용자가 생성된 방을 클릭하여 입장 확인을 눌렀을 때, 해당 기록이 post요청으로 전달됩니다.
- 전달된 post 요청을 DB에 저장하는데, 이미 존재한다면 업데이트합니다.

2. 사용자가 입장했던 방 정보를 주는 get API
- 사용자가 그동안 입장했던 저장된 방의 기록을 전달합니다.
- get API를 호출할 경우, 해당 유저가 현재까지 입장한 방의 기록을 반환 받습니다.

3. N+1 문제 해결을 위한 query 최적화 완료

<br />

## :: 추후 계획
- UserFollowView 수정

<br />

## :: 특이 사항
- 없음