### PR TITLE
Modified: NonTypeError Fixed in FriendRoomView

### DIFF
--- a/rooms/views.py
+++ b/rooms/views.py
@@ -68,21 +68,21 @@ class FriendRoomView(View):
         LIMIT    = int(request.GET.get('display', 8))
 
         follows = Follow.objects.filter(users_id=user.id).select_related('followed').prefetch_related('followed__rooms', 'followed__rooms__rooms_contents')
-        rooms = [room for follow in follows for room in follow.followed.rooms.all()][OFFSET:OFFSET+LIMIT]
-
+        rooms = [room for follow in follows for room in follow.followed.rooms.all()]
+            
         result = [
-            {   
-                'id'            : room.id,
-                'category'      : room.rooms_contents.first().content_categories.name,
-                'is_public'     : room.is_public,
-                'password'      : room.password,
-                'link_url'      : room.rooms_contents.first().content_link_url,
-                'title'         : room.title,
-                'title'         : room.description,
-                'nickname'      : room.users.nickname,
-                'image_url'     : room.rooms_contents.first().thumbnails_url,
-                'published_at'  : room.created_at,
-            } for room in rooms
-        ]
+                {   
+                    'id'            : room.id,
+                    'category'      : room.room_categories.name,
+                    'is_public'     : room.is_public,
+                    'password'      : room.password,
+                    'link_url'      : room.rooms_contents.first().content_link_url,
+                    'title'         : room.title,
+                    'title'         : room.description,
+                    'nickname'      : room.users.nickname,
+                    'image_url'     : room.rooms_contents.first().thumbnails_url,
+                    'published_at'  : room.created_at,
+                } for room in rooms[OFFSET:OFFSET+LIMIT]
+            ]    
 
         return JsonResponse({'message': result}, status=200)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- FriendRoomView의 NonTypeError 수정

<br />

## :: 구현 사항 설명
1. Error 발생 이유
- csv 파일에서 room과 content를 연계시키는 중계모델의 값이 존재하지 않아 room에서 content로 이동할 때 발생되었음

2. 해결 방법
- DB truncate 후, csv파일 수정하여 재삽입 완료

3. 기타 수정
- 방 카테고리 테이블에서 가져올 값을 콘텐츠 카테고리에서 가져오는 문제 수정 완료
- 이로 인해 불필요한 query 감소
