### PR TITLE
Modified: Change Crontab Interval

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -172,5 +172,5 @@ CORS_ALLOW_HEADERS = (
 
 # CRONTAB
 CRONJOBS = [
-    ('0 10,22 * * *', 'config.cron.popular_videos_get_youtube_api', '>> '+os.path.join(BASE_DIR, 'config/log/cron.log'))
+    ('0 0,6,12,18 * * *', 'config.cron.popular_videos_get_youtube_api', '>> '+os.path.join(BASE_DIR, 'config/log/cron.log'))
 ]


### PR DESCRIPTION
## :: 최근 작업 주제
- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- crontab 작동 주기 변경

<br />

## :: 구현 사항 설명
1. crontab 작동 주기 변경 이유 
- Youtube API 통해 실시간 인기 영상을 50개씩 끌어오는 과정에서, 다음 날에도 계속 해당 영상이 인기 영상에 존재하여 콘텐츠 중복문제 발생
- 컨텐츠 중복문제는 이미 저장된 콘텐츠인지 확인하여 DB에 저장하도록 Crontab 기능을 이미 수정 완료
- 현재 중복 데이터는 저장이 안되게끔 처리가 되있기 때문에 저장 주기를 짧게 조정함
- 매일 0시, 6시, 12시, 18시 주기로 Youtube API에 요청을 보내 인기 영상을 가져와, DB에 저장되있지 않은 컨텐츠를 저장함

<br />

## :: 특이 사항
- 없음
